### PR TITLE
Fix typo quickStart

### DIFF
--- a/quickStart.html.haml
+++ b/quickStart.html.haml
@@ -121,7 +121,7 @@ author: Dominik Dary
               // Add the selendroid-test-app to the standalone server
               config.addSupportedApp("src/main/resources/selendroid-test-app-#{site.current_version}.apk");
               selendroidServer = new SelendroidLauncher(config);
-              selendroidServer.lauchSelendroid();
+              selendroidServer.launchSelendroid();
 
       %p The test itself you find <a href="https://github.com/selendroid/demoproject-selendroid/blob/master/src/main/java/io/selendroid/demo/SelendroidIntegrationTest.java#L45">here</a>.
 


### PR DESCRIPTION
lauchSelendroid() should be launchSelendroid()
